### PR TITLE
Capture test failures; detect data races

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,9 +25,10 @@ var (
 
 	additionalTestName = ""
 
-	run  = regexp.MustCompile("=== RUN\\s+(\\w+)")
-	end  = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+(\\w+) \\(([\\.\\d]+)s\\)")
-	race = regexp.MustCompile("^WARNING: DATA RACE")
+	run   = regexp.MustCompile("=== RUN\\s+(\\w+)")
+	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+(\\w+) \\(([\\.\\d]+)s\\)")
+	suite = regexp.MustCompile("^(ok|FAIL)\\w+(\\s+)\\w+([\\.\\d]+)s")
+	race  = regexp.MustCompile("^WARNING: DATA RACE")
 )
 
 func init() {
@@ -93,6 +94,15 @@ func main() {
 			test.Output = strings.Join(out, "|n")
 			out = []string{}
 			continue
+		}
+
+		suiteOut := suite.FindStringSubmatch(line)
+		if suiteOut != nil {
+			if test != nil {
+				fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' message='Test ended in panic.' details='%s']\n", now,
+					testName, test.Output)
+				fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
+			}
 		}
 
 		if race.MatchString(line) {

--- a/main.go
+++ b/main.go
@@ -61,9 +61,11 @@ func main() {
 				if test.Fail {
 					fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' details='%s']\n", now,
 						testName, strings.Join(out, "|n"))
+					fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
 				} else if test.Race {
 					fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' message='Race detected!' details='%s']\n", now,
 						testName, test.Output)
+					fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
 				} else if test.Skip {
 					fmt.Fprintf(output, "##teamcity[testIgnored timestamp='%s' name='%s']\n", now, testName)
 				} else if test.Pass {


### PR DESCRIPTION
This commit captures the actual test failure messages and includes them in the teamcity output. If a data race is detected, the entire standard out of the test (including the data race) will be included in the teamcity output, and the test will be marked as a failure.

I also refactored the regular expression parsing a little bit to reduce duplicate code.
