### PR TITLE
Several bugfixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,6 +90,10 @@ func main() {
 		runOut := run.FindStringSubmatch(line)
 		if runOut != nil {
 			if test != nil {
+				if strings.HasPrefix(runOut[1], test.Name+"/") {
+					// Just ignore subtests.
+					continue
+				}
 				outputTest(test, out)
 			}
 			fmt.Fprintf(output, "##teamcity[testStarted timestamp='%s' name='%s']\n", now,

--- a/main.go
+++ b/main.go
@@ -36,8 +36,9 @@ func init() {
 }
 
 func escapeOutput(outputLines []string) string {
-	newOutput := strings.Join(outputLines, "|n")
+	newOutput := strings.Join(outputLines, "\n")
 	newOutput = strings.Replace(newOutput, "|", "||", -1)
+	newOutput = strings.Replace(newOutput, "\n", "|n", -1)
 	newOutput = strings.Replace(newOutput, "'", "|'", -1)
 	newOutput = strings.Replace(newOutput, "]", "|]", -1)
 	newOutput = strings.Replace(newOutput, "[", "|[", -1)

--- a/main.go
+++ b/main.go
@@ -110,8 +110,10 @@ func main() {
 		if suiteOut != nil {
 			if test != nil {
 				fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' message='Test ended in panic.' details='%s']\n", now,
-					test.Name, test.Output)
+					test.Name, escapeOutput(out))
 				fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, test.Name)
+				out = []string{}
+				continue
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ var (
 
 	additionalTestName = ""
 
-	run   = regexp.MustCompile("=== RUN\\s+(\\w+)")
-	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+(\\w+) \\(([\\.\\d]+)")
+	run   = regexp.MustCompile("=== RUN\\s+([a-zA-Z_]\\S*)")
+	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+([a-zA-Z_]\\S*) \\(([\\.\\d]+)")
 	suite = regexp.MustCompile("^(ok|FAIL)\\s+([^\\s]+)\\s+([\\.\\d]+)s")
 	race  = regexp.MustCompile("^WARNING: DATA RACE")
 )
@@ -111,6 +111,10 @@ func main() {
 			}
 			test.Name = endOut[2]
 			test.Output = escapeOutput(out)
+			if test.Pass || test.Skip {
+				outputTest(test, out)
+				test = nil
+			}
 			out = []string{}
 			continue
 		}
@@ -120,6 +124,7 @@ func main() {
 			if test != nil {
 				outputTest(test, out)
 				out = []string{}
+				test = nil
 				continue
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 		}
 
 		endOut := end.FindStringSubmatch(line)
-		if endOut != nil {
+		if endOut != nil && test != nil {
 			if endOut[1] == "FAIL" {
 				test.Fail = true
 			} else if endOut[1] == "SKIP" {
@@ -137,5 +137,8 @@ func main() {
 		out = append(out, line[:len(line)-1])
 
 		fmt.Fprint(output, line)
+	}
+	if test != nil {
+		outputTest(test, out)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ var (
 
 	run   = regexp.MustCompile("=== RUN\\s+(\\w+)")
 	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+(\\w+) \\(([\\.\\d]+)s\\)")
-	suite = regexp.MustCompile("^(ok|FAIL)\\w+(\\s+)\\w+([\\.\\d]+)s")
+	suite = regexp.MustCompile("^(ok|FAIL)\\s+([^\\s]+)\\s+([\\.\\d]+)s")
 	race  = regexp.MustCompile("^WARNING: DATA RACE")
 )
 


### PR DESCRIPTION
There were a bunch of bugs in handling of panics as well as the TeamCity output itself.

This PR adds support for pre-compiled tests paniccing, subtests, as well as preventing multiple failure output from certain panics. Also, panic output is added to the details of the TeamCity message.

Fixes #6.
