### PR TITLE
Replace carriage returns with |n

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ func escapeOutput(outputLines []string) string {
 	newOutput := strings.Join(outputLines, "\n")
 	newOutput = strings.Replace(newOutput, "|", "||", -1)
 	newOutput = strings.Replace(newOutput, "\n", "|n", -1)
+	newOutput = strings.Replace(newOutput, "\r", "|n", -1)
 	newOutput = strings.Replace(newOutput, "'", "|'", -1)
 	newOutput = strings.Replace(newOutput, "]", "|]", -1)
 	newOutput = strings.Replace(newOutput, "[", "|[", -1)


### PR DESCRIPTION
Stray carriage returns in error messages were breaking the output. This
prevents the breakage at the cost of poorly handling input line ending
encodings that have \r\n and not just one of them.