### PR TITLE
Handle negative test durations and add tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,8 +26,8 @@ var (
 	additionalTestName = ""
 
 	run   = regexp.MustCompile("=== RUN\\s+([a-zA-Z_]\\S*)")
-	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+([a-zA-Z_]\\S*) \\(([\\.\\d]+)")
-	suite = regexp.MustCompile("^(ok|FAIL)\\s+([^\\s]+)\\s+([\\.\\d]+)s")
+	end   = regexp.MustCompile("--- (PASS|SKIP|FAIL):\\s+([a-zA-Z_]\\S*) \\((-?[\\.\\d]+)")
+	suite = regexp.MustCompile("^(ok|FAIL)\\s+([^\\s]+)\\s+(-?[\\.\\d]+)s")
 	race  = regexp.MustCompile("^WARNING: DATA RACE")
 )
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -46,41 +47,33 @@ func escapeOutput(outputLines []string) string {
 	return newOutput
 }
 
-func outputTest(test *Test, out []string) {
+func outputTest(w io.Writer, test *Test, out []string) {
 	now := time.Now().Format(TEAMCITY_TIMESTAMP_FORMAT)
 	var testName = additionalTestName + test.Name
 	if test.Fail {
-		fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' details='%s']\n", now,
+		fmt.Fprintf(w, "##teamcity[testFailed timestamp='%s' name='%s' details='%s']\n", now,
 			testName, escapeOutput(out))
-		fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
+		fmt.Fprintf(w, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
 	} else if test.Race {
-		fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' message='Race detected!' details='%s']\n", now,
+		fmt.Fprintf(w, "##teamcity[testFailed timestamp='%s' name='%s' message='Race detected!' details='%s']\n", now,
 			testName, test.Output)
-		fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
+		fmt.Fprintf(w, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
 	} else if test.Skip {
-		fmt.Fprintf(output, "##teamcity[testIgnored timestamp='%s' name='%s']\n", now, testName)
+		fmt.Fprintf(w, "##teamcity[testIgnored timestamp='%s' name='%s']\n", now, testName)
 	} else if test.Pass {
-		fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
+		fmt.Fprintf(w, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, testName)
 	} else {
-		fmt.Fprintf(output, "##teamcity[testFailed timestamp='%s' name='%s' message='Test ended in panic.' details='%s']\n", now,
+		fmt.Fprintf(w, "##teamcity[testFailed timestamp='%s' name='%s' message='Test ended in panic.' details='%s']\n", now,
 			test.Name, escapeOutput(out))
-		fmt.Fprintf(output, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, test.Name)
+		fmt.Fprintf(w, "##teamcity[testFinished timestamp='%s' name='%s']\n", now, test.Name)
 	}
 }
 
-func main() {
-	flag.Parse()
-
-	if len(additionalTestName) > 0 {
-		additionalTestName += " "
-	}
-
-	reader := bufio.NewReader(input)
-
+func processReader(r *bufio.Reader, w io.Writer) {
 	var out []string
 	var test *Test
 	for {
-		line, err := reader.ReadString('\n')
+		line, err := r.ReadString('\n')
 
 		if err != nil {
 			break
@@ -95,9 +88,9 @@ func main() {
 					// Just ignore subtests.
 					continue
 				}
-				outputTest(test, out)
+				outputTest(w, test, out)
 			}
-			fmt.Fprintf(output, "##teamcity[testStarted timestamp='%s' name='%s']\n", now,
+			fmt.Fprintf(w, "##teamcity[testStarted timestamp='%s' name='%s']\n", now,
 				additionalTestName+runOut[1])
 
 			test = &Test{Name: runOut[1]}
@@ -117,7 +110,7 @@ func main() {
 			test.Name = endOut[2]
 			test.Output = escapeOutput(out)
 			if test.Pass || test.Skip {
-				outputTest(test, out)
+				outputTest(w, test, out)
 				test = nil
 			}
 			out = []string{}
@@ -127,7 +120,7 @@ func main() {
 		suiteOut := suite.FindStringSubmatch(line)
 		if suiteOut != nil {
 			if test != nil {
-				outputTest(test, out)
+				outputTest(w, test, out)
 				out = []string{}
 				test = nil
 				continue
@@ -141,9 +134,21 @@ func main() {
 		}
 		out = append(out, line[:len(line)-1])
 
-		fmt.Fprint(output, line)
+		fmt.Fprint(w, line)
 	}
 	if test != nil {
-		outputTest(test, out)
+		outputTest(w, test, out)
 	}
+}
+
+func main() {
+	flag.Parse()
+
+	if len(additionalTestName) > 0 {
+		additionalTestName += " "
+	}
+
+	reader := bufio.NewReader(input)
+
+	processReader(reader, output)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var (
+	inDir  = "testdata/input/"
+	outDir = "testdata/output/"
+
+	timestampRegexp      = regexp.MustCompile(`timestamp='.*?'`)
+	timestampReplacement = `timestamp=''`
+)
+
+func TestProcessReader(t *testing.T) {
+	files, err := ioutil.ReadDir(inDir)
+	if err != nil {
+		t.Error(err)
+	}
+	for _, file := range files {
+		f, err := os.Open(inDir + file.Name())
+		if err != nil {
+			t.Error(err)
+		}
+		in := bufio.NewReader(f)
+
+		out := &bytes.Buffer{}
+		processReader(in, out)
+		actual := out.String()
+		actual = timestampRegexp.ReplaceAllString(actual, timestampReplacement)
+
+		expectedBytes, err := ioutil.ReadFile(outDir + file.Name())
+		if err != nil {
+			t.Error(err)
+		}
+		expected := string(expectedBytes)
+		expected = timestampRegexp.ReplaceAllString(expected, timestampReplacement)
+
+		if strings.Compare(expected, actual) != 0 {
+			t.Errorf("expected %s, but got %s", expected, actual)
+		}
+	}
+}

--- a/testdata/input/sample
+++ b/testdata/input/sample
@@ -1,0 +1,17 @@
+=== RUN TestSomething
+log output
+--- PASS: TestSomething (0.04s)
+=== RUN TestNegativeDuration
+--- PASS: TestNegativeDuration (-0.04s)
+=== RUN TestFailWithMessage
+--- FAIL: TestFailWithMessage (0.04s)
+foo
+bar
+baz
+=== RUN TestPanic
+explode
+=== RUN TestBlah
+--- PASS: TestBlah (3.05s)
+FAIL
+exit status 1
+FAIL  	github.com/garbageday	0.005s

--- a/testdata/output/sample
+++ b/testdata/output/sample
@@ -1,0 +1,20 @@
+##teamcity[testStarted timestamp='2017-01-30T16:20:54.175' name='TestSomething']
+log output
+##teamcity[testFinished timestamp='2017-01-30T16:20:54.175' name='TestSomething']
+##teamcity[testStarted timestamp='2017-01-30T16:20:54.175' name='TestNegativeDuration']
+##teamcity[testFinished timestamp='2017-01-30T16:20:54.175' name='TestNegativeDuration']
+##teamcity[testStarted timestamp='2017-01-30T16:20:54.175' name='TestFailWithMessage']
+foo
+bar
+baz
+##teamcity[testFailed timestamp='2017-01-30T16:20:54.175' name='TestFailWithMessage' details='foo|nbar|nbaz']
+##teamcity[testFinished timestamp='2017-01-30T16:20:54.175' name='TestFailWithMessage']
+##teamcity[testStarted timestamp='2017-01-30T16:20:54.175' name='TestPanic']
+explode
+##teamcity[testFailed timestamp='2017-01-30T16:20:54.175' name='TestPanic' message='Test ended in panic.' details='explode']
+##teamcity[testFinished timestamp='2017-01-30T16:20:54.175' name='TestPanic']
+##teamcity[testStarted timestamp='2017-01-30T16:20:54.175' name='TestBlah']
+##teamcity[testFinished timestamp='2017-01-30T16:20:54.175' name='TestBlah']
+FAIL
+exit status 1
+FAIL  	github.com/garbageday	0.005s


### PR DESCRIPTION
Make sure we don't choke if `go test` gives us a negative test duration. Also add a basic smoke test.

cc @tamird